### PR TITLE
fixed the styling on the share card when viewed on mobile

### DIFF
--- a/components/graphs/LanguagePie.js
+++ b/components/graphs/LanguagePie.js
@@ -125,7 +125,7 @@ const LanguagePie = ({ repositories }) => {
 
   return (
     <motion.div
-      className="p-3 pb-0 shadow-bs1 rounded-md h-full w-full min-h-[400px] max-w-[380px] bg-white"
+      className="p-3 pb-0 shadow-bs1 rounded-md h-full w-full min-h-[420px] max-w-[380px] bg-white"
       transition={{ duration: 1 }}
       initial={{ scale: 0 }}
       animate={{ scale: 1 }}

--- a/components/social/SocialCard.js
+++ b/components/social/SocialCard.js
@@ -20,7 +20,7 @@ const SocialCard = ({ ogImageUrl, username, loading }) => {
 
   return (
     <motion.div
-      className="flex flex-col justify-between gap-4 py-3 px-3 md:px-5 shadow-bs1 rounded-md h-full w-full min-h-[442px] bg-white"
+      className="flex flex-col justify-between gap-4 py-3 px-3 md:px-5 shadow-bs1 rounded-md h-full w-full min-h-[350px] bg-white"
       transition={{ duration: 1 }}
       initial={{ scale: 0 }}
       animate={{ scale: 1 }}


### PR DESCRIPTION
noticed that the tailwind code was keeping the min height to 442, which caused the card to have some extra white space, this should take care of the issue. 