### PR TITLE
Fix/SocialCardShare 

### DIFF
--- a/components/social/SocialShare.js
+++ b/components/social/SocialShare.js
@@ -38,7 +38,7 @@ const SocialShare = ({ username }) => {
   };
 
   const shareText = `Check out ${username}'s GitHub profile!`;
-  const shareUrl = `${SITE_URL}/profile/${username}`;
+  const shareUrl = `${SITE_URL}/user/${username}`;
 
   return (
     <div className="flex justify-center items-center flex-col gap-4 mb-4">


### PR DESCRIPTION
Fixed The share Link of the Social Card now it redirects to /user/[slug] instead of /profile/[slug]

issue: #46 

